### PR TITLE
Changes the schema name to dimensions.  The way it was originally int…

### DIFF
--- a/models/integrate/prod_dimensions/month_name.sql
+++ b/models/integrate/prod_dimensions/month_name.sql
@@ -3,7 +3,7 @@
         materialized="table",
         alias='month_name', 
         database='integrate', 
-        schema='prod_dimensions'
+        schema='dimensions'
     )
 }}
 


### PR DESCRIPTION
Integrate.prod_prod_dimensions was being created.  It should be integrate.prod_dimensions.  Changed the code to make this happen.