### PR TITLE
Purpose is to copy_grants for integrate, normalize and report.

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -40,7 +40,10 @@ models:
       materialized: table
     integrate:
       materialized: table
+      copy_grants: true
     normalize:
       materialized: view
+      copy_grants: true
     report:
       materialized: view
+      copy_grants: true


### PR DESCRIPTION
According to DBT documentation it's possible to change this file to copy the grants for everything when it's recreated by DBT or it can be done in the configs when a table or view is created.  For now it makes the most sense to do it at the model level.  I only changed integrate, normalize and report because those are the ones I added to the report.