### PR TITLE
Renaming company project from my_new_project to Financial Horizons

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,7 +2,7 @@
 # Name your project! Project names should contain only lowercase characters
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
-name: 'my_new_project'
+name: 'Financial Horizons'
 version: '1.0.0'
 config-version: 2
 


### PR DESCRIPTION
It appears in documentation and logs.  Better to rename it from the default.